### PR TITLE
Functional 2.8 push

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Auto Reload Images - Blender addon
+# Auto Reload Images - Blender (2.80) addon
 
 Handy automatic reload for Image Textures
 
-Just a little handy addon, adding two button in the info header :
+Just a little handy addon, adding two button in the ~~info header~~ properties panel :
 - refresh all images of the blend file
 - use a timer to fetch modified image file and reload them if needed
 

--- a/addon_prefs.py
+++ b/addon_prefs.py
@@ -6,7 +6,7 @@ addon_name = os.path.basename(os.path.dirname(__file__))
 class Reload_AddonPrefs(bpy.types.AddonPreferences):
     bl_idname = addon_name
     
-    check_frequency = bpy.props.FloatProperty(name='Checking Frequency', precision=2, min=0.01, max=3600.00, default=1, description='Frequency for checking for modified Images in seconds')
+    check_frequency : bpy.props.FloatProperty(name='Checking Frequency', precision=2, min=0.01, max=3600.00, default=1, description='Frequency for checking for modified Images in seconds')
 
     def draw(self, context):
         layout = self.layout
@@ -16,5 +16,5 @@ class Reload_AddonPrefs(bpy.types.AddonPreferences):
 
 # get addon preferences
 def get_addon_preferences():
-    addon = bpy.context.user_preferences.addons.get(addon_name)
+    addon = bpy.context.preferences.addons.get(addon_name)
     return getattr(addon, "preferences", None)

--- a/functions.py
+++ b/functions.py
@@ -20,7 +20,8 @@ def reload_images():
             region = [region for region in area.regions if region.type == 'WINDOW']
             if area.type=='VIEW_3D':
                 for space in area.spaces: # iterate through spaces in current VIEW_3D area
-                    if space.type == 'VIEW_3D' and space.viewport_shade == 'RENDERED': # check if space is a 3D view
+                    #print(space.shading.type)
+                    if False and space.type == 'VIEW_3D' and space.shading.type in ['MATERIAL','RENDERED']: # check if space is a 3D view
                         override = {'window':win,
                         'screen':scr,
                         'area'  :area,

--- a/gui.py
+++ b/gui.py
@@ -1,11 +1,21 @@
 import bpy
 
-#menu draw
-def reload_menu_draw(self, context):
-    layout = self.layout
-    row=layout.row(align=True)
-    row.operator('reload.reload_all', text='', icon='FILE_REFRESH', emboss=False)
-    if bpy.data.window_managers['WinMan'].reload_modal==True:
-        row.prop(bpy.data.window_managers['WinMan'], 'reload_modal', text='', icon='CANCEL')
-    else:
-        row.operator('reload.reload_timer', text='', icon='TIME', emboss=False)
+
+class MenuPanel(bpy.types.Panel):
+    """Creates a Panel in the scene context of the properties editor"""
+    bl_label = "Auto Reload Image"
+    bl_idname = "SCENE_PT_AutoReloadImage"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "scene"
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row(align=True)
+        row.operator('reload.reload_all', text='',
+                     icon='FILE_REFRESH', emboss=False)
+        if bpy.data.window_managers['WinMan'].reload_modal == True:
+            row.prop(bpy.data.window_managers['WinMan'],
+                     'reload_modal', text='', icon='CANCEL')
+        else:
+            row.operator('reload.reload_timer', text='', icon='TIME', emboss=False)

--- a/operators.py
+++ b/operators.py
@@ -23,7 +23,7 @@ class Reload_reload_timer(bpy.types.Operator):
     bl_label = "Reload Images timer"
 
     _timer = None
-    oldtimer = bpy.props.FloatProperty()
+    oldtimer : bpy.props.FloatProperty()
     
     def __init__(self):
         
@@ -58,7 +58,7 @@ class Reload_reload_timer(bpy.types.Operator):
         addon_preferences = get_addon_preferences()
         freq=addon_preferences.check_frequency
         wm = context.window_manager
-        self._timer = wm.event_timer_add(freq, context.window)
+        self._timer = wm.event_timer_add(freq, window=context.window)
         wm.modal_handler_add(self)
         return {'RUNNING_MODAL'}
 


### PR DESCRIPTION
Updates to make the addon work in 2.8.
Info bar has been removed so the buttons have been moved to a panel in the Properties > Scene menu.
Recommendation: create a branch or different repository for 2.8 for anyone who still wants the => 2.79 version.